### PR TITLE
Fix capture when no properties are set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-zapier",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "description": "Zapier integration for PostHog.",
     "private": true,
     "license": "MIT",

--- a/src/creates/capture_event.ts
+++ b/src/creates/capture_event.ts
@@ -10,7 +10,7 @@ interface InputData {
 }
 
 async function perform(z: ZObject, bundle: Bundle<InputData>) {
-    const properties: Record<string, any> = bundle.inputData.properties
+    const properties: Record<string, any> = bundle.inputData.properties ?? {}
     // try to interpret property values as JSON (else keep string)
     for (const [key, value] of Object.entries(properties)) {
         try {


### PR DESCRIPTION
If no properties are set on the outgoing event, the code fails with `Cannot convert undefined or null to object`.

Fix this by substituting an empty object if undefined.