### PR TITLE
Rewrite copy for "Action performed" being free

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Developing `posthog-zapier`
+
+Here's how to push a version of `posthog-zapier` without CI:
+
+1. Clone or download this repository.
+1. Enter its directory with `cd`.
+1. Install Node modules.
+    ```bash
+    npm install
+    ```
+1. Globally install Zapier CLI.
+    ```bash
+    npm install -g zapier-platform-cli
+    ```
+1. Log into Zapier from the command line. If you're a PostHog team member, make sure you're part of the PostHog org there.
+    ```bash
+    zapier login
+    ```
+1. Either register a new integration on Zapier.
+    Or link to an existing one.
+    ```bash
+    zapier link
+    ```
+1. Push to Zapier.
+    ```bash
+    npm run push
+    ```
+1. Finish by filling in integration details in the [Zapier Platform dashboard](https://zapier.com/app/developer). If updating an existing integration, deprecate the old version and migrate users to the new one.s

--- a/README.md
+++ b/README.md
@@ -1,49 +1,10 @@
 # PostHog x Zapier
 
-Make the best use of your data. Connect PostHog with _thousands_ of services through Zapier.
+Connect PostHog with _thousands_ of services through Zapier.
 
-The following steps are at your disposal:
+This integration provides two steps you can use in Zaps:
 
-| Type    | Name                      | Plan Required       |
-| :------ | :------------------------ | :------------------ |
-| Action  | Capture Event             | Any, including free |
-| Trigger | Calculated Event Captured | Any **paid** plan   |
-
-## Just want to connect PostHog with practically anything?
-
-[Our official Zapier app](https://zapier.com/apps/posthog/integrations) – compatible with PostHog Cloud as well as with self-hosted solutions – is here for you. No additional setup needed.
+- **Action Performed** trigger, which fires when a selected PostHog action is performed, with the associated event as the payload.
+- **Capture Event** action, which allows you to send events to PostHog.
 
 Try it out now: https://zapier.com/apps/posthog/integrations
-
-## Need something just your own? Developing?
-
-Not a problem. Create a private Zapier app for PostHog easily with this package. It's just a few simple steps:
-
-1. Clone or download this repository.
-2. Enter its directory with `cd`.
-3. Install Node modules.
-    ```bash
-    npm install
-    ```
-4. Update `DEFAULT_API_HOST` value in `src/utils.ts` (e.g. for PostHog Cloud it's `app.posthog.com` and for your self-hosted instance it may be `posthog.example.com`).
-5. Globally install Zapier CLI.
-    ```bash
-    npm install -g zapier-platform-cli
-    ```
-6. Log into Zapier from the command line.
-    ```bash
-    zapier login
-    ```
-7. Either register a new integration on Zapier.
-    ```bash
-    zapier register "PostHog @ $YOUR_ORG"
-    ```
-    Or link to an existing one.
-    ```bash
-    zapier link
-    ```
-8. Push to Zapier.
-    ```bash
-    npm run push
-    ```
-9. Finish by filling in integration details in the [Zapier Platform dashboard](https://zapier.com/app/developer). And don't forget to invite users!

--- a/src/triggers/action_defined.ts
+++ b/src/triggers/action_defined.ts
@@ -1,11 +1,5 @@
 import { Bundle, ZObject } from 'zapier-platform-core'
-import {
-    composeUrl,
-    subscribeHookCreator,
-    unsubscribeHook,
-    TRIGGER_PREMIUM_NOTICE_FIELD,
-    ORGANIZATION_AND_PROJECTS_FIELDS,
-} from '../utils'
+import { composeUrl, subscribeHookCreator, unsubscribeHook, ORGANIZATION_AND_PROJECTS_FIELDS } from '../utils'
 
 function getActionDefinition(z: ZObject, bundle: Bundle) {
     return [bundle.cleanedRequest.data]
@@ -29,7 +23,7 @@ export const ActionDefinedTrigger = {
     },
 
     operation: {
-        inputFields: [TRIGGER_PREMIUM_NOTICE_FIELD, ...ORGANIZATION_AND_PROJECTS_FIELDS],
+        inputFields: ORGANIZATION_AND_PROJECTS_FIELDS,
         type: 'hook',
 
         performSubscribe: subscribeHookCreator('action_defined'),

--- a/src/triggers/action_performed.ts
+++ b/src/triggers/action_performed.ts
@@ -1,11 +1,5 @@
 import { Bundle, ZObject } from 'zapier-platform-core'
-import {
-    composeUrl,
-    subscribeHookCreator,
-    unsubscribeHook,
-    TRIGGER_PREMIUM_NOTICE_FIELD,
-    ORGANIZATION_AND_PROJECTS_FIELDS,
-} from '../utils'
+import { composeUrl, subscribeHookCreator, unsubscribeHook, ORGANIZATION_AND_PROJECTS_FIELDS } from '../utils'
 
 function getActionPerformance(z: ZObject, bundle: Bundle) {
     return [bundle.cleanedRequest.data]
@@ -56,7 +50,6 @@ export const ActionPerformedTrigger = {
 
     operation: {
         inputFields: [
-            TRIGGER_PREMIUM_NOTICE_FIELD,
             ...ORGANIZATION_AND_PROJECTS_FIELDS,
             {
                 key: 'action_id',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,13 +5,6 @@ export const POSTHOG_CLOUD_HOST: string = 'app.posthog.com' // DO NOT CHANGE
 export const DEFAULT_API_HOST: string = POSTHOG_CLOUD_HOST // You can change to something like: posthog.hogflix.com
 export const DEFAULT_LABEL: string = 'PostHog Cloud' // You can change to something like: Hogflix
 
-export const TRIGGER_PREMIUM_NOTICE_FIELD = {
-    key: 'premium_notice',
-    helpText:
-        '**Important:** Triggers are a premium PostHog feature. Make sure that you are on a paid plan, otherwise the trigger will not fire.',
-    type: 'copy',
-}
-
 const ORGANIZATION_FIELD = {
     key: 'organization_id',
     label: 'Organization',


### PR DESCRIPTION
A cleanup of the in-Zapier UI as well as README.md, accounting for "Action performed" being free, and Slack not being active anymore.